### PR TITLE
Customize the MFD text

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,20 @@ inactive = ["off", "off"]
 active = ["on", "green"]
 blocked = ["off", "off"]
 alert = ["flash", "green-flash"]
+
+[mfd]
+line1 = "EDXLC"
+line2 = ""
+line3 = ""
 ```
 
 The `hardpoints-deployed` and `night-vision` sections are optional and will
 fall back to the values in `default` if missing.
+
+The `[mfd]` section allows you to customize the three lines of text displayed on
+the X52 Pro's Multi-Function Display (MFD). If this section is missing, the
+first line defaults to `EDXLC`. Each line supports up to 16 characters. Lines
+longer than 16 characters will scroll.
 
 For each state you specify the light mode for boolean and red/amber/green
 lights. For boolean lights, the supported modes are:
@@ -89,7 +99,7 @@ For red/amber/green ligths, the supported modes are:
 
 To use an alternative configuration file specify it as a command line argument:
 
-```
+```text
 edxlc.exe C:\Path\To\My\config.toml
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -310,7 +310,7 @@ mod tests {
             night_vision: None,
             silent_running: None,
             mfd: None,
-      };
+        };
 
         let actual_mapper = config.status_level_to_mode_mapper(GlobalStatus::Normal);
         let expected_mapper = StatusLevelToModeMapper {

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,14 @@ pub struct Config {
     default: ModeConfig,
     hardpoints_deployed: Option<ModeConfig>,
     night_vision: Option<ModeConfig>,
+    mfd: Option<MfdConfig>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize, Default)]
+pub struct MfdConfig {
+    pub line1: Option<String>,
+    pub line2: Option<String>,
+    pub line3: Option<String>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
@@ -96,6 +104,38 @@ impl Config {
             .expect("Can't find user app data directory")
             .join(DEFAULT_BINDINGS_FILE_PATH)
     }
+
+    /// Returns the MFD configuration if provided.
+    pub fn mfd(&self) -> Option<&MfdConfig> {
+        self.mfd.as_ref()
+    }
+
+    /// Returns the MFD lines as a vector of strings.
+    pub fn mfd_lines(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(mfd) = &self.mfd {
+            if let Some(line1) = &mfd.line1 {
+                lines.push(line1.clone());
+            } else {
+                lines.push(String::new());
+            }
+            if let Some(line2) = &mfd.line2 {
+                lines.push(line2.clone());
+            } else {
+                lines.push(String::new());
+            }
+            if let Some(line3) = &mfd.line3 {
+                lines.push(line3.clone());
+            } else {
+                lines.push(String::new());
+            }
+        } else {
+            lines.push(String::from("EDXLC"));
+            lines.push(String::new());
+            lines.push(String::new());
+        }
+        lines
+    }
 }
 
 /// Returns the `LightMode` value corresponding to the mode tuple.
@@ -133,6 +173,11 @@ pub fn write_default_file_if_missing(config_filename: &str) {
             active: (BooleanLightMode::On, RedAmberGreenLightMode::Green),
             blocked: (BooleanLightMode::Off, RedAmberGreenLightMode::Off),
             alert: (BooleanLightMode::Flash, RedAmberGreenLightMode::GreenFlash),
+        }),
+        mfd: Some(MfdConfig {
+            line1: Some(String::from("EDXLC")),
+            line2: None,
+            line3: None,
         }),
     };
 
@@ -187,6 +232,7 @@ mod tests {
                 blocked: (BooleanLightMode::Off, RedAmberGreenLightMode::Red),
                 alert: (BooleanLightMode::On, RedAmberGreenLightMode::RedAmber),
             }),
+            mfd: None,
         };
 
         assert_eq!(Config::from_toml(&String::from(toml)), expected);
@@ -211,6 +257,7 @@ mod tests {
             },
             hardpoints_deployed: None,
             night_vision: None,
+            mfd: None,
         };
 
         assert_eq!(Config::from_toml(&String::from(toml)), expected);
@@ -241,6 +288,7 @@ mod tests {
                 alert: other_light_config,
             }),
             night_vision: None,
+            mfd: None,
         };
 
         let actual_mapper = config.status_level_to_mode_mapper(GlobalStatus::Normal);
@@ -274,6 +322,7 @@ mod tests {
                 blocked: night_vision_light_config,
                 alert: night_vision_light_config,
             }),
+            mfd: None,
         };
 
         let actual_mapper = config.status_level_to_mode_mapper(GlobalStatus::NightVisionOn);
@@ -313,6 +362,7 @@ mod tests {
             },
             hardpoints_deployed: None,
             night_vision: None,
+            mfd: None,
         };
 
         let expected_mapper = StatusLevelToModeMapper {

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,7 +35,7 @@ struct Files {
 }
 
 const DEFAULT_BINDINGS_FILE_PATH: &str =
-    r"Frontier Developments\Elite Dangerous\Options\Bindings\Custom.4.0.binds";
+    r"Frontier Developments\Elite Dangerous\Options\Bindings\Custom.4.2.binds";
 
 impl Config {
     /// Returns a new instance constructed by loading the give configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ const ANIMATION_TICK_MILLISECONDS: u64 = x52pro::ALERT_FLASH_MILLISECONDS as u64
 
 pub fn run(config: Config) {
     let mut x52pro = Device::new();
+    x52pro.set_mfd_text(config.mfd_lines());
 
     let bindings_file_path = config.bindings_file_path();
     debug!("Bindings file path: {:?}", bindings_file_path);

--- a/src/x52pro/device.rs
+++ b/src/x52pro/device.rs
@@ -156,6 +156,15 @@ impl Device {
             light_mapping.update_state(&self.direct_output, &self.light_mode_to_state_mapper);
         }
     }
+
+    /// Sets the text on the MFD display.
+    pub fn set_mfd_text(&self, text_lines: Vec<String>) {
+        for (index, text) in text_lines.iter().enumerate() {
+            if index < 3 {
+                self.direct_output.set_string(index as u32, text);
+            }
+        }
+    }
 }
 
 /// Supported input buttons or axes on the device.

--- a/src/x52pro/direct_output.rs
+++ b/src/x52pro/direct_output.rs
@@ -28,6 +28,13 @@ type SetLedFn = unsafe extern "C" fn(
     dwIndex: DWORD,
     dwValue: DWORD,
 ) -> HRESULT;
+type SetStringFn = unsafe extern "C" fn(
+    hDevice: DeviceHandle,
+    dwPage: DWORD,
+    dwIndex: DWORD,
+    cchValue: DWORD,
+    wszValue: *const wchar_t,
+) -> HRESULT;
 
 const FLAG_SET_AS_ACTIVE: DWORD = 1;
 
@@ -48,6 +55,7 @@ pub struct DirectOutput {
     enumerate_fn: Symbol<EnumerateFn>,
     add_page_fn: Symbol<AddPageFn>,
     set_led_fn: Symbol<SetLedFn>,
+    set_string_fn: Symbol<SetStringFn>,
     device: DeviceHandle,
 }
 
@@ -61,6 +69,7 @@ impl DirectOutput {
         let enumerate_fn = Self::get_library_symbol(&library, b"DirectOutput_Enumerate");
         let add_page_fn = Self::get_library_symbol(&library, b"DirectOutput_AddPage");
         let set_led_fn = Self::get_library_symbol(&library, b"DirectOutput_SetLed");
+        let set_string_fn = Self::get_library_symbol(&library, b"DirectOutput_SetString");
 
         Self {
             library,
@@ -68,6 +77,7 @@ impl DirectOutput {
             enumerate_fn,
             add_page_fn,
             set_led_fn,
+            set_string_fn,
             device: std::ptr::null(),
         }
     }
@@ -159,6 +169,29 @@ impl DirectOutput {
 
             if result != 0 {
                 panic!("Can't set LED, return value {}", result);
+            }
+        }
+    }
+
+    /// Sets the text on the MFD display at the given `index`. The `index` must
+    /// be between 0 and 2 inclusive for the X52Pro. Panics if setting the
+    /// string fails.
+    pub fn set_string(&self, index: u32, text: &str) {
+        debug!("Setting MFD string {} to \"{}\"", index, text);
+
+        let wide_string = Self::win32_string(text);
+
+        unsafe {
+            let result = (self.set_string_fn)(
+                self.device,
+                PAGE_ID,
+                index,
+                text.len() as DWORD,
+                wide_string.as_ptr(),
+            );
+
+            if result != 0 {
+                panic!("Can't set MFD string, return value {}", result);
             }
         }
     }


### PR DESCRIPTION
This adds the ability to customize the 3 lines in the MFD to anything you want.

It's done by a new section in the config file, named `[mfd]`. The Readme is updated accordingly